### PR TITLE
Portability

### DIFF
--- a/emulator/Common.h
+++ b/emulator/Common.h
@@ -65,7 +65,7 @@ void DebugLogFormat(LPCTSTR pszFormat, ...);
 
 
 // Processor register names
-const TCHAR* REGISTER_NAME[];
+extern const TCHAR* REGISTER_NAME[8] ;
 
 const int UKNC_SCREEN_WIDTH = 640;
 const int UKNC_SCREEN_HEIGHT = 288;

--- a/emulator/ConsoleView.cpp
+++ b/emulator/ConsoleView.cpp
@@ -87,8 +87,8 @@ void ConsoleView_Create(HWND hwndParent, int x, int y, int width, int height)
     SetWindowText(g_hwndConsole, _T("Debug Console"));
 
     // ToolWindow subclassing
-    m_wndprocConsoleToolWindow = (WNDPROC) LongToPtr( SetWindowLongPtr(
-            g_hwndConsole, GWLP_WNDPROC, PtrToLong(ConsoleViewWndProc)) );
+    m_wndprocConsoleToolWindow = (WNDPROC)SetWindowLongPtr(
+      g_hwndConsole, GWLP_WNDPROC, (LONG_PTR)ConsoleViewWndProc);
 
     RECT rcConsole;  GetClientRect(g_hwndConsole, &rcConsole);
 
@@ -120,8 +120,8 @@ void ConsoleView_Create(HWND hwndParent, int x, int y, int width, int height)
     SendMessage(m_hwndConsoleLog, WM_SETFONT, (WPARAM) m_hfontConsole, 0);
 
     // Edit box subclassing
-    m_wndprocConsoleEdit = (WNDPROC) LongToPtr( SetWindowLongPtr(
-            m_hwndConsoleEdit, GWLP_WNDPROC, PtrToLong(ConsoleEditWndProc)) );
+    m_wndprocConsoleEdit = (WNDPROC)SetWindowLongPtr(
+      m_hwndConsoleEdit, GWLP_WNDPROC, (LONG_PTR)(ConsoleEditWndProc));
 
     ShowWindow(g_hwndConsole, SW_SHOW);
     UpdateWindow(g_hwndConsole);

--- a/emulator/DebugView.cpp
+++ b/emulator/DebugView.cpp
@@ -98,8 +98,8 @@ void DebugView_Create(HWND hwndParent, int x, int y, int width, int height)
     DebugView_UpdateWindowText();
 
     // ToolWindow subclassing
-    m_wndprocDebugToolWindow = (WNDPROC)LongToPtr( SetWindowLongPtr(
-            g_hwndDebug, GWLP_WNDPROC, PtrToLong(DebugViewWndProc)) );
+    m_wndprocDebugToolWindow = (WNDPROC)SetWindowLongPtr(
+      g_hwndDebug, GWLP_WNDPROC, (LONG_PTR)DebugViewWndProc);
 
     RECT rcClient;  GetClientRect(g_hwndDebug, &rcClient);
 

--- a/emulator/DisasmView.cpp
+++ b/emulator/DisasmView.cpp
@@ -154,8 +154,8 @@ void DisasmView_Create(HWND hwndParent, int x, int y, int width, int height)
     DisasmView_UpdateWindowText();
 
     // ToolWindow subclassing
-    m_wndprocDisasmToolWindow = (WNDPROC) LongToPtr( SetWindowLongPtr(
-            g_hwndDisasm, GWLP_WNDPROC, PtrToLong(DisasmViewWndProc)) );
+    m_wndprocDisasmToolWindow = (WNDPROC)SetWindowLongPtr(
+      g_hwndDisasm, GWLP_WNDPROC, (LONG_PTR)DisasmViewWndProc);
 
     RECT rcClient;  GetClientRect(g_hwndDisasm, &rcClient);
 

--- a/emulator/Main.h
+++ b/emulator/Main.h
@@ -10,7 +10,7 @@ UKNCBTL. If not, see <http://www.gnu.org/licenses/>. */
 
 #pragma once
 
-#include "res\\resource.h"
+#include "res\\Resource.h"
 
 //////////////////////////////////////////////////////////////////////
 

--- a/emulator/MemoryView.cpp
+++ b/emulator/MemoryView.cpp
@@ -95,8 +95,8 @@ void MemoryView_Create(HWND hwndParent, int x, int y, int width, int height)
     MemoryView_UpdateWindowText();
 
     // ToolWindow subclassing
-    m_wndprocMemoryToolWindow = (WNDPROC) LongToPtr( SetWindowLongPtr(
-            g_hwndMemory, GWLP_WNDPROC, PtrToLong(MemoryViewWndProc)) );
+    m_wndprocMemoryToolWindow = (WNDPROC)SetWindowLongPtr(
+      g_hwndMemory, GWLP_WNDPROC, (LONG_PTR)MemoryViewWndProc);
 
     RECT rcClient;  GetClientRect(g_hwndMemory, &rcClient);
 

--- a/emulator/Settings.cpp
+++ b/emulator/Settings.cpp
@@ -234,7 +234,7 @@ BOOL Settings_LoadBinaryValue(LPCTSTR sName, void * pData, int size)
         m_Settings_##PARAMNAME##_Valid = TRUE; \
         Settings_SaveDwordValue(PARAMNAMESTR, (DWORD) newvalue); \
     } \
-    OUTTYPE Settings_Get##PARAMNAME##() { \
+    OUTTYPE Settings_Get##PARAMNAME () { \
         if (!m_Settings_##PARAMNAME##_Valid) { \
             DWORD dwValue = (DWORD) DEFVALUE; \
             Settings_LoadDwordValue(PARAMNAMESTR, &dwValue); \

--- a/emulator/SoundGen.cpp
+++ b/emulator/SoundGen.cpp
@@ -10,7 +10,7 @@ UKNCBTL. If not, see <http://www.gnu.org/licenses/>. */
 
 // SoundGen.cpp
 
-#include "StdAfx.h"
+#include "stdafx.h"
 #include "emubase\Emubase.h"
 #include "SoundGen.h"
 #include "Mmsystem.h"

--- a/emulator/SpriteView.cpp
+++ b/emulator/SpriteView.cpp
@@ -117,8 +117,8 @@ void SpriteView_Create(int x, int y)
             NULL, NULL, g_hInst, NULL);
 
     // ToolWindow subclassing
-    m_wndprocSpriteToolWindow = (WNDPROC)LongToPtr(SetWindowLongPtr(
-            g_hwndSprite, GWLP_WNDPROC, PtrToLong(SpriteViewWndProc)));
+    m_wndprocSpriteToolWindow = (WNDPROC)SetWindowLongPtr(
+            g_hwndSprite, GWLP_WNDPROC, (LONG_PTR)SpriteViewWndProc);
 
     RECT rcClient;  GetClientRect(g_hwndSprite, &rcClient);
 

--- a/emulator/TapeView.cpp
+++ b/emulator/TapeView.cpp
@@ -115,8 +115,8 @@ void TapeView_Create(HWND hwndParent, int x, int y, int width, int height)
     SetWindowText(g_hwndTape, _T("Tape"));
 
     // ToolWindow subclassing
-    m_wndprocTapeToolWindow = (WNDPROC) LongToPtr( SetWindowLongPtr(
-            g_hwndTape, GWLP_WNDPROC, PtrToLong(TapeViewWndProc)) );
+    m_wndprocTapeToolWindow = (WNDPROC)SetWindowLongPtr(
+            g_hwndTape, GWLP_WNDPROC, (LONG_PTR)TapeViewWndProc);
 
     RECT rcClient;  GetClientRect(g_hwndTape, &rcClient);
 

--- a/emulator/manifest.xml
+++ b/emulator/manifest.xml
@@ -7,7 +7,7 @@
        type="win32"
        name="Microsoft.Windows.Common-Controls"
        version="6.0.0.0"
-       processorArchitecture="X86"
+       processorArchitecture="*"
        publicKeyToken="6595b64144ccf1df"
        language="*"
    />


### PR DESCRIPTION
fixed some portability issues preventing building with clang (non conformant macro concatenation and forward declaration)
fixed 32bit-64bit portability issue with narrowed pointer conversion (running on 64-bit windows cause general protection fault)

